### PR TITLE
Add missing HAVE_OPENMP in cvconfig.h.in which fix OpenMP parallel ba…

### DIFF
--- a/cmake/templates/cvconfig.h.in
+++ b/cmake/templates/cvconfig.h.in
@@ -115,6 +115,9 @@
 /* parallel_for with pthreads */
 #cmakedefine HAVE_PTHREADS_PF
 
+/* parallel_for with OpenMP */
+#cmakedefine HAVE_OPENMP
+
 /* Intel Threading Building Blocks */
 #cmakedefine HAVE_TBB
 


### PR DESCRIPTION
Add missing HAVE_OPENMP in cvconfig.h.in which fixes OpenMP parallel backend load. 

Closes #23369.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [*] I agree to contribute to the project under Apache 2 License.
- [*] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [*] The PR is proposed to the proper branch
- [*] There is a reference to the original bug report and related work
- [*] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [*] The feature is well documented and sample code can be built with the project CMake
